### PR TITLE
Update README with correct npm link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # spatie-attachment-uploader
 
-[![Latest Version on NPM](https://img.shields.io/npm/v/spatie-attachment-uploader.svg?style=flat-square)](https://npmjs.com/package/spatie-attachment-uploader)
+[![Latest Version on NPM](https://img.shields.io/npm/v/@spatie/attachment-uploader.svg?style=flat-square)](https://www.npmjs.com/package/@spatie/attachment-uploader)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
 
 ```js


### PR DESCRIPTION
The changed introduced in https://github.com/spatie/spatie-attachment-uploader/commit/a62d16e2ea8d45c56d43ef1a8a04ada641961fc4 was not reflected in the README badge.